### PR TITLE
Allow the Jira client to support custom CA certificates

### DIFF
--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -54,6 +54,8 @@ module JIRA
         http_conn.cert = @options[:cert]
         http_conn.key = @options[:key]
       end
+      http_conn.ca_path = @options[:ca_path] if @options[:ca_path]
+      http_conn.ca_file = @options[:ca_file] if @options[:ca_file]
       http_conn.verify_mode = @options[:ssl_verify_mode]
       http_conn.read_timeout = @options[:read_timeout]
       http_conn

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -195,6 +195,22 @@ describe JIRA::HttpClient do
     expect(basic_client_cert_client.http_conn(uri)).to eq(http_conn)
   end
 
+  it 'can use a Certificate Authority certificate file' do
+    client = JIRA::HttpClient.new(JIRA::Client::DEFAULT_OPTIONS.merge(ca_file: 'CA Cert Contents'))
+
+    http_conn = client.http_conn(client.uri)
+
+    expect(http_conn.ca_file).to eql('CA Cert Contents')
+  end
+
+  it 'can use a Certificate Authority certificate by path' do
+    client = JIRA::HttpClient.new(JIRA::Client::DEFAULT_OPTIONS.merge(ca_path: '/tmp/CA.crt'))
+
+    http_conn = client.http_conn(client.uri)
+
+    expect(http_conn.ca_path).to eql('/tmp/CA.crt')
+  end
+
   it "returns a http connection" do
     http_conn = double()
     uri = double()


### PR DESCRIPTION
It has support to use a custom client certificate, but not to use a
custom certificate for the Certificate Authority. This commit allows to
pass the ca_file and/or the ca_path options to use in the HTTP
connection.